### PR TITLE
Reduced the search radius for Gaia cone search from 5 to 2 arcseconds.

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from astroquery.gaia import Gaia
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 
-SEARCH_RADIUS = 5 * u.arcsec       # radius for Gaia cone search [2]
+SEARCH_RADIUS = 2 * u.arcsec       # radius for Gaia cone search [2]
 DIST_TOL = 0.2                     # ±20% distance window for candidate match [2]
 
 # 1) Load data


### PR DESCRIPTION
This change is based on a review of common practices in astronomical research for finding optical counterparts to pulsars. A smaller search radius reduces the probability of chance alignments, leading to a higher confidence in the matched candidates.

The distance tolerance (`DIST_TOL`) of 20% was also evaluated and found to be a reasonable value, as pulsar distance measurements often have significant uncertainties. This parameter was left unchanged.